### PR TITLE
Include time header

### DIFF
--- a/src/components/Map/Markers/MarkerContainer.tsx
+++ b/src/components/Map/Markers/MarkerContainer.tsx
@@ -30,29 +30,44 @@ export type MarkerData = {
 
 const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted }) => {
   const [ticketInspectorList, setTicketInspectorList] = useState<MarkerData[]>([]);
-
- useEffect(() => {
+  useEffect(() => {
+   
     const fetchData = async () => {
-        const newTicketInspectorList = await getRecentTicketInspectorInfo();
-        if (JSON.stringify(newTicketInspectorList) !== JSON.stringify(ticketInspectorList)) {
-          setTicketInspectorList(newTicketInspectorList);
+      // change name lastUpdateTime for understanding
+        const lastUpdateTime = localStorage.getItem('lastUpdateTime');
+        if (!lastUpdateTime) {
+            console.log('No lastUpdateTime found in local storage.');
+            const currentTime = new Date().toISOString();
+            localStorage.setItem('lastUpdateTime', currentTime);
+        }
+        const newTicketInspectorList = await getRecentTicketInspectorInfo(lastUpdateTime); 
+        console.log(newTicketInspectorList, ticketInspectorList);
+        // Only update ticketInspectorList if newTicketInspectorList is an array
+        if (Array.isArray(newTicketInspectorList)) {
+            setTicketInspectorList(newTicketInspectorList);
+
+            // Assuming the array is sorted with the most recent timestamp first
+            if (newTicketInspectorList.length > 0) {
+                // Update lastUpdateTime in local storage with the most recent timestamp
+                const latestReturnedTimestamp = newTicketInspectorList[0].timestamp;
+                localStorage.setItem('lastUpdateTime', latestReturnedTimestamp);
+            }
+        } else {
+            console.log('No new data to update.');
         }
     };
 
     fetchData();
-
+    console.log(ticketInspectorList)
     const interval = setInterval(fetchData, 5000);
 
-    return () => {
-        clearInterval(interval);
-    };
-}, [ticketInspectorList, formSubmitted]);
+    return () => clearInterval(interval);
+}, [formSubmitted]);
 
   return (
     <div>
       {
         ticketInspectorList.map((ticketInspector, index) => {
-
             return (
               <OpacityMarker markerData={ticketInspector} index={index} key={ticketInspector.station.id}/>
             );

--- a/src/components/Map/Markers/MarkerContainer.tsx
+++ b/src/components/Map/Markers/MarkerContainer.tsx
@@ -30,18 +30,18 @@ export type MarkerData = {
 
 const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted }) => {
   const [ticketInspectorList, setTicketInspectorList] = useState<MarkerData[]>([]);
-  const lastRecievedInspectorTimestamp = useRef<string | null>(null);
+  const lastReceivedInspectorTimestamp = useRef<string | null>(null);
 
   useEffect(() => {
     const fetchData = async () => {
-        const newTicketInspectorList = await getRecentTicketInspectorInfo(lastRecievedInspectorTimestamp.current) || [];
+        const newTicketInspectorList = await getRecentTicketInspectorInfo(lastReceivedInspectorTimestamp.current) || [];
 
-        // Only reset the markers if we are getting new data
+        // Check if the new array is not empty, then update the state
         if (Array.isArray(newTicketInspectorList) && newTicketInspectorList.length > 0) {
             setTicketInspectorList(newTicketInspectorList);
 
             // Update lastUpdateTime in local storage with the most recent timestamp
-            lastRecievedInspectorTimestamp.current = newTicketInspectorList[0].timestamp;
+            lastReceivedInspectorTimestamp.current = newTicketInspectorList[0].timestamp;
         }
     };
 

--- a/src/components/Map/Markers/MarkerContainer.tsx
+++ b/src/components/Map/Markers/MarkerContainer.tsx
@@ -34,12 +34,12 @@ const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted }) => {
 
   useEffect(() => {
     const fetchData = async () => {
-        const newTicketInspectorList = await getRecentTicketInspectorInfo(lastRecievedInspectorTimestamp.current) || []; 
+        const newTicketInspectorList = await getRecentTicketInspectorInfo(lastRecievedInspectorTimestamp.current) || [];
 
         // Only reset the markers if we are getting new data
         if (Array.isArray(newTicketInspectorList) && newTicketInspectorList.length > 0) {
             setTicketInspectorList(newTicketInspectorList);
-            
+
             // Update lastUpdateTime in local storage with the most recent timestamp
             lastRecievedInspectorTimestamp.current = newTicketInspectorList[0].timestamp;
         }
@@ -50,7 +50,6 @@ const MarkerContainer: React.FC<MarkersProps> = ({ formSubmitted }) => {
 
     return () => clearInterval(interval);
 }, [formSubmitted, ticketInspectorList]);
-
 
   return (
     <div>

--- a/src/functions/dbUtils.tsx
+++ b/src/functions/dbUtils.tsx
@@ -1,13 +1,33 @@
 import { MarkerData } from '../components/Map/Markers/MarkerContainer';
 
-export async function getRecentTicketInspectorInfo(): Promise<MarkerData[]> {
+export async function getRecentTicketInspectorInfo(lastUpdateTimestamp: string | null): Promise<MarkerData[] | null> {
     try {
-        const response = await fetch('/recent');
+        const headers = new Headers();
+        console.log(lastUpdateTimestamp + " ss ");
+        // Include the If-Modified-Since header only if lastUpdateTimestamp is available
+        if (lastUpdateTimestamp && lastUpdateTimestamp !== "undefined") {
+            headers.append("If-Modified-Since", lastUpdateTimestamp);
+            console.log('Headersss:', headers);
+        }
+
+        // Make the request with optional If-Modified-Since header
+        const response = await fetch('/recent', {
+            method: 'GET',
+            headers: headers,
+        });
+
+    
+
+        // Handle 304 Not Modified
+        if (response.status === 304) {
+            return null;
+        }
+
         const data = await response.json();
         return data;
     } catch (error) {
         console.error('Error:', error);
-        return [];
+        return []; // Return an empty array in case of error
     }
 }
 

--- a/src/functions/dbUtils.tsx
+++ b/src/functions/dbUtils.tsx
@@ -3,11 +3,10 @@ import { MarkerData } from '../components/Map/Markers/MarkerContainer';
 export async function getRecentTicketInspectorInfo(lastUpdateTimestamp: string | null): Promise<MarkerData[] | null> {
     try {
         const headers = new Headers();
-        console.log(lastUpdateTimestamp + " ss ");
+
         // Include the If-Modified-Since header only if lastUpdateTimestamp is available
-        if (lastUpdateTimestamp && lastUpdateTimestamp !== "undefined") {
+        if (lastUpdateTimestamp) {
             headers.append("If-Modified-Since", lastUpdateTimestamp);
-            console.log('Headersss:', headers);
         }
 
         // Make the request with optional If-Modified-Since header
@@ -15,8 +14,6 @@ export async function getRecentTicketInspectorInfo(lastUpdateTimestamp: string |
             method: 'GET',
             headers: headers,
         });
-
-    
 
         // Handle 304 Not Modified
         if (response.status === 304) {

--- a/src/functions/dbUtils.tsx
+++ b/src/functions/dbUtils.tsx
@@ -3,10 +3,9 @@ import { MarkerData } from '../components/Map/Markers/MarkerContainer';
 export async function getRecentTicketInspectorInfo(lastUpdateTimestamp: string | null): Promise<MarkerData[] | null> {
     try {
         const headers = new Headers();
-
         // Include the If-Modified-Since header only if lastUpdateTimestamp is available
         if (lastUpdateTimestamp) {
-            headers.append("If-Modified-Since", lastUpdateTimestamp);
+            headers.append('If-Modified-Since', lastUpdateTimestamp);
         }
 
         // Make the request with optional If-Modified-Since header


### PR DESCRIPTION
This is should be merged after: https://github.com/FreiFahren/backend/pull/50.

When a user makes a request for the first time the server will simply fetch all of the stations since the header is empty, after getting the inspector data we are setting the last modified timestamp to be that of the last inspector we are getting and making a new request that only returns something if the newest timestamp in the db is newer that the timestamp from the frontend.

In the frontend we are only rerendering the markers if we are getting new ones.