### PR TITLE
Fix flickering

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,14 +33,5 @@
     
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      <!-- To create a production bundle, use `npm run build` or `yarn build`. -->
   </body>
 </html>

--- a/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
+++ b/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
@@ -14,8 +14,9 @@ export const OpacityMarker = ({ markerData, index }: { markerData: MarkerData; i
 
     useEffect(() => {
         // ensures that intervalId is defined before it's used
+        // eslint-disable-next-line prefer-const
         let intervalId: NodeJS.Timeout;
-        
+
         const calculateOpacity = () => {
             const currentTime = new Date().getTime();
             const elapsedTime = currentTime - timestampSeconds;
@@ -45,10 +46,10 @@ export const OpacityMarker = ({ markerData, index }: { markerData: MarkerData; i
     }
 
     return (
-        <Marker 
+        <Marker
             ref={markerRef}
             key={`${line}-${index}`}
-            position={[station.coordinates.latitude, station.coordinates.longitude]} 
+            position={[station.coordinates.latitude, station.coordinates.longitude]}
             icon={OpacityMarkerIcon(opacity)}
         >
             <Popup>

--- a/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
+++ b/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
@@ -6,7 +6,7 @@ import { OpacityMarkerIcon } from '../../../../../functions/mapUtils';
 let icon = OpacityMarkerIcon(1);
 
 export const OpacityMarker = ({ markerData, index }: { markerData: MarkerData; index: number; }) => {
-    const [opacity, setOpacity] = useState(1);
+    const [opacity, setOpacity] = useState(0);
     const { timestamp, station, line, direction } = markerData;
 
     const timestampSeconds = new Date(timestamp.replace(/T|Z/g, ' ')).getTime();

--- a/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
+++ b/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
@@ -22,13 +22,16 @@ export const OpacityMarker = ({ markerData, index }: { markerData: MarkerData; i
     };
 
     useEffect(() => {
+        // Get the initial opacity value
+        calculateOpacity();
+
         const interval = setInterval(() => {
             calculateOpacity();
 
             if (opacity === 0) {
                 clearInterval(interval);
             }
-        }, 1000);
+        }, 3000);
 
         return () => {
             clearInterval(interval);

--- a/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
+++ b/src/components/Map/Markers/Classes/OpacityMarker/OpacityMarker.tsx
@@ -2,62 +2,57 @@ import { Marker, Popup } from 'react-leaflet';
 import { MarkerData } from '../../MarkerContainer';
 import { OpacityMarkerIcon } from '../../../../../functions/mapUtils';
 import L from 'leaflet';
-import { useRef, useEffect, useCallback, useState } from 'react';
+import { useRef, useEffect, useState } from 'react';
 
 export const OpacityMarker = ({ markerData, index }: { markerData: MarkerData; index: number; }) => {
-    const [opacity, setOpacity] = useState(0);
+    const [opacity, setOpacity] = useState(1); // full opacity so that the component renders initially
     const { timestamp, station, line, direction } = markerData;
 
     const timestampSeconds = new Date(timestamp.replace(/T|Z/g, ' ')).getTime();
 
-    const markerRef = useRef<L.Marker | null>(null); // Create a ref to store the marker instance
-
-    const calculateOpacity = useCallback(() => { // Wrapped in useCallback
-        const currentTime = new Date().getTime();
-        const elapsedTime = currentTime - timestampSeconds;
-        const opacityValue = Math.max(0, 1 - (elapsedTime / (15 * 60 * 1000)));
-        setOpacity(opacityValue);
-        return opacityValue;
-    }, [timestampSeconds]); // timestampSeconds is a dependency
+    const markerRef = useRef<L.Marker | null>(null);
 
     useEffect(() => {
-        calculateOpacity();
-
-        const interval = setInterval(() => {
-            calculateOpacity();
-
-            if (opacity === 0) {
-                clearInterval(interval);
+        // ensures that intervalId is defined before it's used
+        let intervalId: NodeJS.Timeout;
+        
+        const calculateOpacity = () => {
+            const currentTime = new Date().getTime();
+            const elapsedTime = currentTime - timestampSeconds;
+            const newOpacity = Math.max(0, 1 - (elapsedTime / (15 * 60 * 1000)));
+            setOpacity(newOpacity);
+            if (newOpacity === 0) {
+                clearInterval(intervalId);
             }
-        }, 3000);
-
-        return () => {
-            clearInterval(interval);
         };
-    }, [calculateOpacity, opacity]); // calculateOpacity is now a stable function
+
+        calculateOpacity(); // Initial calculation
+
+        intervalId = setInterval(calculateOpacity, 5000); // every 5 seconds to avoid excessive rerenders
+
+        return () => clearInterval(intervalId);
+    }, [timestampSeconds]); // runs when getting a new timestamp
 
     useEffect(() => {
-        if (markerRef.current) {
+        if (markerRef.current && opacity > 0) {
             const newIcon = OpacityMarkerIcon(opacity);
-            markerRef.current.setIcon(newIcon); // Update the icon of the marker instance
+            markerRef.current.setIcon(newIcon);
         }
-    }, [opacity]); // Run this effect whenever the opacity changes
+    }, [opacity]);
 
-    if (opacity === 0) {
+    if (opacity <= 0) {
         return null;
     }
 
     return (
         <Marker 
-            ref={markerRef} // Pass the ref to the Marker component
-            key={`${line}-${index}`} 
+            ref={markerRef}
+            key={`${line}-${index}`}
             position={[station.coordinates.latitude, station.coordinates.longitude]} 
             icon={OpacityMarkerIcon(opacity)}
         >
             <Popup>
-                <>
-                    {line} {direction.name ? direction.name + ' - ' : ''} {station.name} {opacity.toFixed(2)}
-                </>
+                {`${line} ${direction.name ? direction.name + ' - ' : ''} ${station.name}`}
             </Popup>
         </Marker>
     );


### PR DESCRIPTION
Fix: #39

I have fixed the issue that when refreshing the page all of the markers were set to a high opacity at removed again a second later. I fixed this by setting the initial rendered opacity to the actual opacity and also improved performance by avoiding excessive rerenders. 

The OpacityMarker will now only be rerendered every 5 seconds this means that not the entire component will be rerendered but only the Marker component.   

And the opacity is set on render on not after the first interval. 

These changes make the marker appear faster, fix flickering and improve the performance.

