### PR TITLE
Spam prot

### DIFF
--- a/src/components/ReportForm/ReportForm.tsx
+++ b/src/components/ReportForm/ReportForm.tsx
@@ -59,7 +59,7 @@ const ReportForm: React.FC<ReportFormProps> = ({
 
 		// Check for last report time to prevent spamming
 		const lastReportTime = localStorage.getItem('lastReportTime');
-		if (lastReportTime && Date.now() - parseInt(lastReportTime) < 1 * 60 * 1000) {
+		if (lastReportTime && Date.now() - parseInt(lastReportTime) < 30 * 60 * 1000) {
 			highlightElement('report-form');
 			createWarningSpan('station-select-div', 'Du kannst nur alle 30 Minuten eine Meldung abgeben!');
 			hasError = true;

--- a/src/components/ReportForm/ReportForm.tsx
+++ b/src/components/ReportForm/ReportForm.tsx
@@ -59,9 +59,9 @@ const ReportForm: React.FC<ReportFormProps> = ({
 
 		// Check for last report time to prevent spamming
 		const lastReportTime = localStorage.getItem('lastReportTime');
-		if (lastReportTime && Date.now() - parseInt(lastReportTime) < 30 * 60 * 1000) {
+		if (lastReportTime && Date.now() - parseInt(lastReportTime) < 15 * 60 * 1000) {
 			highlightElement('report-form');
-			createWarningSpan('station-select-div', 'Du kannst nur alle 30 Minuten eine Meldung abgeben!');
+			createWarningSpan('station-select-div', 'Du kannst nur alle 15 Minuten eine Meldung abgeben!');
 			hasError = true;
 		}
 

--- a/src/components/ReportForm/ReportForm.tsx
+++ b/src/components/ReportForm/ReportForm.tsx
@@ -54,18 +54,16 @@ const ReportForm: React.FC<ReportFormProps> = ({
 
 	const emptyOption = '' as unknown as selectOption;
 
-	const handleSubmit = async (event: React.FormEvent) => {
-		event.preventDefault();
+	const validateReportForm = async () => {
+		let hasError = false;
 
-		// Check if 30 minutes have passed since the last report
+		// Check for last report time to prevent spamming
 		const lastReportTime = localStorage.getItem('lastReportTime');
-		if (lastReportTime && Date.now() - parseInt(lastReportTime) < 30 * 60 * 1000) {
+		if (lastReportTime && Date.now() - parseInt(lastReportTime) < 1 * 60 * 1000) {
 			highlightElement('report-form');
 			createWarningSpan('station-select-div', 'Du kannst nur alle 30 Minuten eine Meldung abgeben!');
-			return;
+			hasError = true;
 		}
-
-		let hasError = false;
 
 		if (reportFormState.stationInput === undefined || reportFormState.stationInput === emptyOption) {
 			highlightElement('station-select-component__control');
@@ -79,16 +77,22 @@ const ReportForm: React.FC<ReportFormProps> = ({
 
 		const locationError = await verifyUserLocation(reportFormState.stationInput, reportFormState.stationsList);
 		if (locationError) {
-			hasError = true; // Update hasError based on location verification
+			hasError = true;
 		}
 
-		if (hasError) return; // If there is an error, do not proceed with the submission
+		return hasError; // Return true if there's an error, false otherwise
+	};
+
+	const handleSubmit = async (event: React.FormEvent) => {
+		event.preventDefault();
+
+		const hasError = await validateReportForm();
+		if (hasError) return; // Abort submission if there are validation errors
 
 		const { lineInput, stationInput, directionInput } = reportFormState;
-
 		await reportInspector(lineInput!, stationInput!, directionInput!);
 
-		// Save the timestamp of the report
+		// Save the timestamp of the report to prevent spamming
 		localStorage.setItem('lastReportTime', Date.now().toString());
 
 		closeModal();

--- a/src/components/ReportForm/ReportForm.tsx
+++ b/src/components/ReportForm/ReportForm.tsx
@@ -57,6 +57,14 @@ const ReportForm: React.FC<ReportFormProps> = ({
 	const handleSubmit = async (event: React.FormEvent) => {
 		event.preventDefault();
 
+		// Check if 30 minutes have passed since the last report
+		const lastReportTime = localStorage.getItem('lastReportTime');
+		if (lastReportTime && Date.now() - parseInt(lastReportTime) < 30 * 60 * 1000) {
+			highlightElement('report-form');
+			createWarningSpan('station-select-div', 'Du kannst nur alle 30 Minuten eine Meldung abgeben!');
+			return;
+		}
+
 		let hasError = false;
 
 		if (reportFormState.stationInput === undefined || reportFormState.stationInput === emptyOption) {
@@ -79,6 +87,9 @@ const ReportForm: React.FC<ReportFormProps> = ({
 		const { lineInput, stationInput, directionInput } = reportFormState;
 
 		await reportInspector(lineInput!, stationInput!, directionInput!);
+
+		// Save the timestamp of the report
+		localStorage.setItem('lastReportTime', Date.now().toString());
 
 		closeModal();
 		onFormSubmit(); // Notify App component about the submission


### PR DESCRIPTION
# Pull Request Template

## Description

Every time that a user reports a station the time will be saved in localstorage, before reporting it is then checked if the timestramp is older than 30 minutes. If it is newer it will prevent the report by highlighting and showing an error. This should prevent people from spamming the db.

Fixes: #58

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I tested with a report out of my reach, with a report within my reach without the timestamp, with to new timestamp, with time stamp older than 30 minutes, with no station.

## Checklist:

Before submitting your PR, please review the following checklist:

- [x] I have performed a self-review of my own code or materials.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
