### PR TITLE
43 save the stations and lines list in localstorage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,7 @@ export default tseslint.config(
       'jsx-quotes': ['error', 'prefer-single'],
       'no-trailing-spaces': ['error'],
       'no-multiple-empty-lines': ['error', { 'max': 1 }],
-      'eslint no-console': ["error", { allow: ["warn", "error"] }]
+      'no-console': ["error", { allow: ["warn", "error"] }]
     }
   }
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ export default tseslint.config(
       'jsx-quotes': ['error', 'prefer-single'],
       'no-trailing-spaces': ['error'],
       'no-multiple-empty-lines': ['error', { 'max': 1 }],
+      'eslint no-console': ["error", { allow: ["warn", "error"] }]
     }
   }
 );

--- a/src/components/ReportForm/ReportForm.tsx
+++ b/src/components/ReportForm/ReportForm.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { ActionMeta } from 'react-select/';
+import { LatLngTuple } from 'leaflet';
 
 import { LinesList, StationList, StationProperty, getAllLinesList, getAllStationsList, reportInspector } from '../../functions/dbUtils';
 import AutocompleteInputForm, { selectOption } from '../AutocompleteInputForm/AutocompleteInputForm';
 import { highlightElement, redefineDirectionOptions, redefineLineOptions, redefineStationOptions, createWarningSpan } from '../../functions/uiUtils';
 import { calculateDistance } from '../../functions/mapUtils';
 import './ReportForm.css';
-import { LatLngTuple } from 'leaflet';
+
 
 interface ReportFormProps {
   closeModal: () => void;
@@ -35,8 +36,8 @@ const initialState: reportFormState = {
 	lineOptions: [],
 	stationOptions: [],
 	directionOptions: [],
-	stationsList: {},
-	linesList: {},
+	stationsList: localStorage.getItem('stationsList') ? JSON.parse(localStorage.getItem('stationsList')!) : {} as StationList,
+	linesList: localStorage.getItem('linesList') ? JSON.parse(localStorage.getItem('linesList')!) : {} as LinesList,
 	isLoadingLines: true,
 	isLoadingStations: true,
 };
@@ -127,13 +128,32 @@ const ReportForm: React.FC<ReportFormProps> = ({
 
 	const refreshOptions = async (type: 'lines' | 'stations') => {
 		try {
-			setReportFormState(prevState => ({ ...prevState,
-				[type === 'lines' ? 'isLoadingLines' : 'isLoadingStations']: true }));
+			setReportFormState(prevState => ({ ...prevState, [type === 'lines' ? 'isLoadingLines' : 'isLoadingStations']: true }));
+			let list = (type === 'lines') ? {} as LinesList : {} as StationList;
 
-			const list = type === 'lines' ? await getAllLinesList() : await getAllStationsList();
+			const storedList = JSON.parse(localStorage.getItem(`${type}List`) || 'null');
+
+			if (storedList === null || (Date.now() - storedList.timestamp) > 24 * 60 * 60 * 1000) {
+				const fetchedList = (type === 'lines') ? await getAllLinesList() : await getAllStationsList();
+				if (JSON.stringify(storedList?.list) !== JSON.stringify(fetchedList)) {
+					console.log(`Fetched ${type}List is different, updating...`);
+					list = fetchedList;
+					localStorage.setItem(`${type}List`, JSON.stringify({ list, timestamp: Date.now() }));
+				} else {
+					console.log(`Fetched ${type}List is the same, not updating...`);
+					list = storedList.list;
+				}
+			} else {
+				console.log(` Loading ${type}List`)
+				list = storedList.list;
+			}
+
 			const options = Object.keys(list).map(key => ({ value: key, label: type === 'lines' ? key : (list[key] as StationProperty).name }));
 
-			setReportFormState(prevState => ({ ...prevState, [type === 'lines' ? 'linesList' : 'stationsList']: list, [type === 'lines' ? 'lineOptions' : 'stationOptions']: options }));
+			setReportFormState(prevState => ({
+				...prevState, [type === 'lines' ? 'linesList' : 'stationsList']: list,
+				[type === 'lines' ? 'lineOptions' : 'stationOptions']: options
+			}));
 
 		} catch (error) {
 			console.error(`Failed to fetch ${type}:`, error);

--- a/src/components/ReportForm/ReportForm.tsx
+++ b/src/components/ReportForm/ReportForm.tsx
@@ -8,7 +8,6 @@ import { highlightElement, redefineDirectionOptions, redefineLineOptions, redefi
 import { calculateDistance } from '../../functions/mapUtils';
 import './ReportForm.css';
 
-
 interface ReportFormProps {
   closeModal: () => void;
   onFormSubmit: () => void;
@@ -136,15 +135,12 @@ const ReportForm: React.FC<ReportFormProps> = ({
 			if (storedList === null || (Date.now() - storedList.timestamp) > 24 * 60 * 60 * 1000) {
 				const fetchedList = (type === 'lines') ? await getAllLinesList() : await getAllStationsList();
 				if (JSON.stringify(storedList?.list) !== JSON.stringify(fetchedList)) {
-					console.log(`Fetched ${type}List is different, updating...`);
 					list = fetchedList;
 					localStorage.setItem(`${type}List`, JSON.stringify({ list, timestamp: Date.now() }));
 				} else {
-					console.log(`Fetched ${type}List is the same, not updating...`);
 					list = storedList.list;
 				}
 			} else {
-				console.log(` Loading ${type}List`)
 				list = storedList.list;
 			}
 
@@ -200,7 +196,7 @@ const ReportForm: React.FC<ReportFormProps> = ({
 		const fetchData = async () => {
 			await refreshOptions('stations');
 			await refreshOptions('lines');
-		};
+		}
 
 		fetchData();
 	}, []);


### PR DESCRIPTION
## Description

When the user loads the report form for the first time, the data is  fetched and saved to localstorage.
When going back to the app, it checks if there is something in the localstorage and if the saved timestamp inside it is older than one day. If not, it'll load the local storage. If yes, it'll fetch again and save data + new timestamp

(also added eslint rule to not have console logs inside the code)
Fixes: #43 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

see loom

## Checklist:

Before submitting your PR, please review the following checklist:

- [X] I have performed a self-review of my own code or materials.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] Any dependent changes have been merged and published in downstream modules.

## Additional Information:

Any additional information that you believe is important and relevant to the review of this PR.
